### PR TITLE
Add support for ignore files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - v6
   - v5
   - v4
   - '0.12'
-  - '0.10'
 after_script:
   - 'npm run coveralls'

--- a/README.md
+++ b/README.md
@@ -30,18 +30,52 @@ gulp.task('default', () =>
 
 ### gulpRemark([options])
 
-Gulp plug-in. It processes your files through [remark][remark]. If you want to define specified options, use [`.remarkrc`][remarkrc]. The ignoring of files available using [`.remarkignore`][remarkignore] file.
+Gulp plug-in. It processes your files through [remark][remark]. If you want to define specified options, use [`.remarkrc`][remarkrc]. The ignoring of files available using [`.remarkignore`][remarkignore] file. So, it’s more like the [`remark-cli`][cli].
 
 #### options
 
 Type: `Object`  
 Default: `{}`
 
-Passed to remark. [See its documentation][remark-settings].
+The [parse][remark-parse-settings] and [stringify][remark-stringify-settings] settings can be passed in
+`options.settings`, or in configuration files (`.remarkrc`, `package.json`).
+
+*   [`settings`][settings] (`Object`, optional)
+    — Configuration for the parser and compiler of the processor.
+*   [`detectConfig`][detect-config] (`boolean`, default: `true`)
+    — Whether to search for configuration files.
+*   [`detectIgnore`][detect-ignore] (`boolean`, default: `true`)
+    — Whether to search for ignore files.
+*   [`rcPath`][rc-path] (`string`, optional)
+    — File-path to a configuration file to load.
+*   [`ignorePath`][ignore-path] (`string`, optional)
+    — File-path to an ignore file to load.
+*   [`silent`][silent] (`boolean`, default: `false`)
+    — Report only fatal errors.
+*   [`quiet`][quiet] (`boolean`, default: `silent`)
+    — Do not report successful files.
+*   [`frail`][frail] (`boolean`, default: `false`)
+    — Treat warnings as errors.
+*   [`streamError`][stream-error] (`WritableStream`, default: `process.stderr`)
+    — Stream to write the report (if any) to.
+*   [`plugins`][plugins] (`Object`, optional)
+    — Map of plug-in names or paths and options to use.
+*   [`tree`][tree] (`boolean`, default: `false`)
+    — Whether to treat both input and output as a syntax tree.
+*   [`treeIn`][tree-in] (`boolean`, default: `tree`)
+    — Whether to treat input as a syntax tree.
+*   [`treeOut`][tree-out] (`boolean`, default: `tree`)
+    — Whether to treat output as a syntax tree.
+*   [`color`][color] (`boolean`, default: `false`)
+    — Whether to report with ANSI colour sequences.
 
 ### gulpRemark().use([plugin][remark-plugins][, options])
 
 Change the way [`remark`][remark] works by using a [`plugin`][remark-plugins].
+
+> **Note:** Be careful not to pass plug-ins which are also detected
+> (for example, from configuration files), as this results in the
+> same plug-in being attached multiple times.
 
 #### plugin
 
@@ -62,11 +96,13 @@ Passed to plugin. Specified by its documentation.
 MIT © [Denys Dovhan](http://denysdovhan.com)
 
 [remark]: http://remark.js.org/
-[remarkrc]: https://github.com/wooorm/remark/blob/master/doc/remarkrc.5.md
-[remarkignore]: https://github.com/wooorm/remark/blob/master/doc/remarkignore.5.md
-[remark-use]: https://github.com/wooorm/remark#remarkuseplugin-options
+[cli]: https://github.com/wooorm/remark/tree/master/packages/remark-cli
+[remarkrc]: https://github.com/wooorm/unified-engine/blob/master/doc/configure.md
+[remarkignore]: https://github.com/wooorm/unified-engine/blob/master/doc/ignore.md
+[remark-use]: https://github.com/wooorm/unified#processoruseplugin-options
 [remark-plugins]: https://github.com/wooorm/remark/blob/master/doc/plugins.md
-[remark-settings]: https://github.com/wooorm/remark#remarkprocessvalue-options-done
+[remark-parse-settings]: https://github.com/wooorm/remark/tree/master/packages/remark-parse#processoruseparse
+[remark-stringify-settings]: https://github.com/wooorm/remark/tree/master/packages/remark-stringify#processorusestringify
 
 [npm-url]: https://npmjs.org/package/gulp-remark
 [npm-image]: https://img.shields.io/npm/v/gulp-remark.svg?style=flat-square
@@ -79,3 +115,18 @@ MIT © [Denys Dovhan](http://denysdovhan.com)
 
 [depstat-url]: https://david-dm.org/denysdovhan/gulp-remark
 [depstat-image]: https://david-dm.org/denysdovhan/gulp-remark.svg?style=flat-square
+
+[detect-config]: https://github.com/wooorm/unified-engine/blob/master/doc/options.md#optionsdetectconfig
+[stream-error]: https://github.com/wooorm/unified-engine/blob/master/doc/options.md#optionsstreamerror
+[tree]: https://github.com/wooorm/unified-engine/blob/master/doc/options.md#optionstree
+[tree-in]: https://github.com/wooorm/unified-engine/blob/master/doc/options.md#optionstreein
+[tree-out]: https://github.com/wooorm/unified-engine/blob/master/doc/options.md#optionstreeout
+[rc-path]: https://github.com/wooorm/unified-engine/blob/master/doc/options.md#optionsrcpath
+[settings]: https://github.com/wooorm/unified-engine/blob/master/doc/options.md#optionssettings
+[detect-ignore]: https://github.com/wooorm/unified-engine/blob/master/doc/options.md#optionsdetectignore
+[ignore-path]: https://github.com/wooorm/unified-engine/blob/master/doc/options.md#optionsignorepath
+[plugins]: https://github.com/wooorm/unified-engine/blob/master/doc/options.md#optionsplugins
+[color]: https://github.com/wooorm/unified-engine/blob/master/doc/options.md#optionscolor
+[silent]: https://github.com/wooorm/unified-engine/blob/master/doc/options.md#optionssilent
+[quiet]: https://github.com/wooorm/unified-engine/blob/master/doc/options.md#optionsquiet
+[frail]: https://github.com/wooorm/unified-engine/blob/master/doc/options.md#optionsfrail

--- a/index.js
+++ b/index.js
@@ -1,74 +1,13 @@
-import { PluginError } from 'gulp-util';
-import { obj }         from 'through2';
-import toVFile         from 'convert-vinyl-to-vfile';
-import CLI             from 'remark/lib/cli/cli';
-import run             from 'remark/lib/cli';
-import reporter        from 'vfile-reporter';
+import engine from 'unified-engine-gulp';
+import remark from 'remark';
 
 import pkg from './package';
 
-const PLUGIN_NAME = pkg.name;
-
-const DEFAULT_OPTIONS = {
-  detectRC:     true,
-  detectIgnore: true
-};
-
-export default function gulpRemark(OPTIONS) {
-
-  const options = Object.assign(DEFAULT_OPTIONS, OPTIONS);
-
-  const cli = new CLI({
-    detectRC:     options.detectRC,
-    detectIgnore: options.detectIgnore,
-    settings:     options,
-    cwd:          process.cwd(),
-    stdout:       process.stdout,
-    stderr:       process.stderr
-  });
-
-  const plugin = obj(function (file, encoding, callback) {
-    if (file.isNull()) {
-      return callback(null, file);
-    }
-
-    if (file.isStream()) {
-      return callback(new PluginError(PLUGIN_NAME, 'Streaming not supported'));
-    }
-
-    if (file.isBuffer()) {
-      const VFile = toVFile(file);
-      cli.files = [VFile];
-
-      run(cli, (error, success) => {
-        if (error) {
-          callback(error);
-        } else if (cli.traverser.ignore.shouldIgnore(VFile.basename())) {
-          // Return callback if file is in .remarkignore
-          callback(null, file);
-        } else {
-          // if not silent, output messages
-          if (!options.silent) {
-            console.log(reporter(cli.files));
-          }
-
-          // Throw error if frail is enabled
-          if (options.frail && !success) {
-            callback(new PluginError(PLUGIN_NAME, 'Unsuccessful running'));
-          }
-
-          // Return transformed contents
-          file.contents = new Buffer(cli.files[0].contents, 'utf-8');
-          callback(null, file);
-        }
-      });
-    }
-  });
-
-  plugin.use = (pls, opts) => {
-    cli.use(pls, opts);
-    return plugin;
-  };
-
-  return plugin;
-};
+export default engine({
+  name: pkg.name,
+  processor: remark,
+  rcName: '.remarkrc',
+  packageField: 'remarkConfig',
+  ignoreName: '.remarkignore',
+  pluginPrefix: 'remark'
+});

--- a/package.json
+++ b/package.json
@@ -35,11 +35,8 @@
   },
   "homepage": "https://github.com/denysdovhan/gulp-remark#readme",
   "dependencies": {
-    "convert-vinyl-to-vfile": "^0.1.1",
-    "gulp-util": "^3.0.7",
-    "remark": "^4.0.0",
-    "through2": "^2.0.0",
-    "vfile-reporter": "^1.5.0"
+    "remark": "^5.0.0",
+    "unified-engine-gulp": "^1.0.0"
   },
   "devDependencies": {
     "assert": "*",
@@ -51,10 +48,11 @@
     "babel-preset-es2015": "^6.1.18",
     "coveralls": "*",
     "event-stream": "^3.3.2",
+    "gulp-util": "^3.0.7",
     "isparta": "*",
     "mocha": "*",
     "npm-run-all": "*",
-    "remark-html": "^2.0.2",
+    "remark-html": "^5.0.0",
     "rimraf": "*"
   }
 }

--- a/test.js
+++ b/test.js
@@ -28,7 +28,7 @@ it('should not do anything', done => {
 
 it('should support settings', done => {
   const stream = gulpRemark({
-    commonmark: true,
+    settings: {commonmark: true},
     silent: true
   }).use(html);
 


### PR DESCRIPTION
Hi @denysdovhan!
-  Update remark to version 5.0.0;
-  Use `unified-engine-gulp` to deal with processing, this adds
  proper support for `.remarkignore` files, all different `.remarkrc`
  files.

I recently did a lot of normalisation around the CLI part of remark, one of the things is that it’s now easier to integrate in gulp! I even created a small wrapper around the “engine“ to work with Gulp: https://github.com/wooorm/unified-engine-gulp, which is fully tested and works great!

This adds some new functionality, but also includes a major change:

Before:

``` js
gulpRemark({commonmark: true, frail: true})
```

After:

``` js
gulpRemark({settings: {commonmark: true}, frail: true});
```

...plus, I think this closes GH-8!
