### PR TITLE
[fix] fix the wrong package name in the example of readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ npm install --save-dev gulp-remark
 
 ```js
 var gulp = require('gulp')
-var remark = require('remark-gulp')
+var remark = require('gulp-remark')
 var html = require('remark-html')
 var lint = require('remark-preset-lint-markdown-style-guide')
 


### PR DESCRIPTION
`gulp-remark` is miswritten to `remark-gulp`, which lead to an error when I try to run the example code