### PR TITLE
Bump unified-engine-gulp from 8.0.0 to 8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "remark": "^12.0.0",
-    "unified-engine-gulp": "^8.0.0"
+    "unified-engine-gulp": "^8.1.0"
   },
   "devDependencies": {
     "nyc": "^15.0.0",


### PR DESCRIPTION
unified-engine-gulp 8.1.0 features sharing data between vinyl and vfile. See unifiedjs/unified-engine-gulp#20.